### PR TITLE
3.0.1

### DIFF
--- a/policies/intel-aws-emr-instance-fleet-deny-unapproved-instance-types/test/intel-aws-emr-instance-fleet-deny-unapproved-instance-types/failure.hcl
+++ b/policies/intel-aws-emr-instance-fleet-deny-unapproved-instance-types/test/intel-aws-emr-instance-fleet-deny-unapproved-instance-types/failure.hcl
@@ -5,12 +5,12 @@ mock "tfplan/v2" {
 }
 
 import "static" "approved" {
-  source = "../../../../../imports/static/approvedinstances.json"
+  source = "../../../../approved.json"
   format = "json"
 }
 
 import "module" "policy_summary" {
-  source = "../../../../../imports/modules/policy_summary.sentinel"
+  source = "../../../../modules/policysummary.sentinel"
 }
 
 test {

--- a/policies/intel-aws-emr-instance-fleet-deny-unapproved-instance-types/test/intel-aws-emr-instance-fleet-deny-unapproved-instance-types/success.hcl
+++ b/policies/intel-aws-emr-instance-fleet-deny-unapproved-instance-types/test/intel-aws-emr-instance-fleet-deny-unapproved-instance-types/success.hcl
@@ -5,12 +5,12 @@ mock "tfplan/v2" {
 }
 
 import "static" "approved" {
-  source = "../../../../../imports/static/approvedinstances.json"
+  source = "../../../../approved.json"
   format = "json"
 }
 
 import "module" "policy_summary" {
-  source = "../../../../../imports/modules/policy_summary.sentinel"
+  source = "../../../../modules/policysummary.sentinel"
 }
 
 test {


### PR DESCRIPTION
Summary of Changes:

- Fixed typo in `success.hcl` for emr-cluster-instance-fleet file paths of module and static import
- Fixed typo in `failure.hcl` for emr-cluster-instance-fleet file paths of module and static import